### PR TITLE
Prevent growing metrics cardinality

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Feline.addConsumerLast(new MetricsConsumer(registry));
 This will create a meter tagged with `what: blocking-calls` and `call`
 referring to the class and method name that called the blocking
 `Future` or `CompletableFuture` method.
+There is also a tag with `thread_name` referring to the thread that called
+the blocking method. To prevent a metrics cardinality explosion, this
+name is sanitized by replacing all integers with the character `N`. 
 
 You can customize how the caller is identified by
 injecting a custom `CallFinder` to the `MetricsConsumer` - take a look at the

--- a/semantic-metrics/src/test/java/com/spotify/feline/MetricsConsumerTest.java
+++ b/semantic-metrics/src/test/java/com/spotify/feline/MetricsConsumerTest.java
@@ -19,6 +19,7 @@ package com.spotify.feline;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.util.concurrent.SettableFuture;
@@ -130,8 +131,9 @@ public class MetricsConsumerTest {
   }
 
   private void assertMetric(final String call) {
+    final String expectedThreadName = MetricsConsumer.sanitizeThreadName(Thread.currentThread().getName());
     final MetricId expectedId =
-        BLOCKING_CALL_ID.tagged("call", call, "thread_name", Thread.currentThread().getName());
+        BLOCKING_CALL_ID.tagged("call", call, "thread_name", expectedThreadName);
     assertTrue(
         "Did not find meter with id="
             + expectedId
@@ -190,5 +192,11 @@ public class MetricsConsumerTest {
         finder.findCall(elements, "java.util.concurrent.Future.get");
     assertTrue(stackTraceElement.isPresent());
     assertThat(stackTraceElement.get(), is(sameInstance(elements[2])));
+  }
+
+  @Test
+  public void testSanitizeThread() {
+    assertEquals("thread-N-N", MetricsConsumer.sanitizeThreadName("thread-2-10"));
+    assertEquals("thread-N-N-pool", MetricsConsumer.sanitizeThreadName("thread-256-123-pool"));
   }
 }


### PR DESCRIPTION
We can have an infinitely growing set of thread names that have
been used by the JVM. By replacing all numbers with a
constant character, we can minimize that problem, since thread pools
typically use counters when creating new threads.