### PR TITLE
Add distribution management to BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -9,6 +9,17 @@
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
The BOM doesn't inherit the parent and thus need it's own distribution
management config.