### PR TITLE
Update byte-buddy to 1.10.20

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        java: [ 8, 11, 13 ]
+        java: [ 8, 11, 13, 15 ]
 
     steps:
     - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -120,12 +120,12 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.9.13</version>
+        <version>1.10.20</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.9.13</version>
+        <version>1.10.20</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
For Java 15 support, and better integration with Mockito.