### PR TITLE
bump byte-buddy to 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,12 +120,12 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.10.20</version>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.10.20</version>
+        <version>1.11.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Looks like mostly bugfixes: https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.11.0