### PR TITLE
move allowances Map from Feline class to avoid possible deadlock

### DIFF
--- a/feline/src/main/java/com/spotify/feline/AllowancesTransformer.java
+++ b/feline/src/main/java/com/spotify/feline/AllowancesTransformer.java
@@ -43,12 +43,12 @@ class AllowancesTransformer implements AgentBuilder.Transformer, ElementMatcher<
   void allow(final String className, final String methodName) {
     allowances.compute(
         className,
-        (key, allowances) -> {
-          if (allowances == null) {
-            allowances = new HashSet<>();
+        (key, set) -> {
+          if (set == null) {
+            set = new HashSet<>();
           }
-          allowances.add(methodName);
-          return allowances;
+          set.add(methodName);
+          return set;
         });
   }
 

--- a/feline/src/main/java/com/spotify/feline/AllowancesTransformer.java
+++ b/feline/src/main/java/com/spotify/feline/AllowancesTransformer.java
@@ -18,7 +18,6 @@
 package com.spotify.feline;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -26,13 +25,14 @@ import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.utility.JavaModule;
 
 /**
  * This transformer applies {@link AllowAdvice} to every method registered with {@link
  * Feline#allowBlockingCallsInside(String, String)}.
  */
-class AllowancesTransformer implements AgentBuilder.Transformer {
+class AllowancesTransformer implements AgentBuilder.Transformer, ElementMatcher<TypeDescription> {
 
   private final ConcurrentMap<String, Set<String>> allowances;
 
@@ -52,8 +52,9 @@ class AllowancesTransformer implements AgentBuilder.Transformer {
         });
   }
 
-  boolean containsClass(String name) {
-    return allowances.containsKey(name);
+  @Override
+  public boolean matches(final TypeDescription typeDescription) {
+    return allowances.containsKey(typeDescription.getName());
   }
 
   @Override

--- a/feline/src/main/java/com/spotify/feline/Feline.java
+++ b/feline/src/main/java/com/spotify/feline/Feline.java
@@ -32,7 +32,7 @@ import net.bytebuddy.matcher.ElementMatchers;
 /** Detects blocking calls to @link CompletableFuture and notifies registered consumers. */
 public class Feline {
 
-  private static final Map<String, Set<String>> allowances = new ConcurrentHashMap<>();
+  private static final AllowancesTransformer allowancesTransformer = new AllowancesTransformer();
 
   /**
    * Registers a consumer that will be invoked when blocking calls are detected. Consumers can throw
@@ -152,15 +152,7 @@ public class Feline {
    * @param methodName a method name
    */
   public static void allowBlockingCallsInside(final String className, final String methodName) {
-    allowances.compute(
-        className,
-        (key, allowances) -> {
-          if (allowances == null) {
-            allowances = new HashSet<>();
-          }
-          allowances.add(methodName);
-          return allowances;
-        });
+    allowancesTransformer.allow(className, methodName);
   }
 
   /**
@@ -214,8 +206,8 @@ public class Feline {
         .asTerminalTransformation()
 
         // Instrument allowed/disallowed methods
-        .type(it -> allowances.containsKey(it.getName()))
-        .transform(new AllowancesTransformer(allowances))
+        .type(it -> allowancesTransformer.containsClass(it.getName()))
+        .transform(allowancesTransformer)
         .asTerminalTransformation()
 
         // instrument ThreadLocal

--- a/feline/src/main/java/com/spotify/feline/Feline.java
+++ b/feline/src/main/java/com/spotify/feline/Feline.java
@@ -18,7 +18,6 @@ package com.spotify.feline;
 
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -206,7 +205,7 @@ public class Feline {
         .asTerminalTransformation()
 
         // Instrument allowed/disallowed methods
-        .type(it -> allowancesTransformer.containsClass(it.getName()))
+        .type(allowancesTransformer)
         .transform(allowancesTransformer)
         .asTerminalTransformation()
 


### PR DESCRIPTION
This is an attempt to fix #18 by simply moving the Map out of the Feline class, so that when bytebuddy checks to see if a type matches the filter there is no need to load or access `com.spotify.feline.Feline`. My thought is then that any thread doing something that causes bytebuddy to invoke methods in an `AllowancesTransformer` instance has no need to wait for `com.spotify.feline.Feline` to finish being initialized.

 I don't feel 100% confident this fixes the problem until a reliable way to reproduce #18 can be found.