### PR TITLE
ensure tests are actually executed for 'feline' module

### DIFF
--- a/feline/pom.xml
+++ b/feline/pom.xml
@@ -26,6 +26,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,9 @@
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>2.22.2</version>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>com.coveo</groupId>


### PR DESCRIPTION
I noticed that, at least locally, the tests in the feline module are not
actually executing:

```
[INFO] --- maven-surefire-plugin:2.22.2:test (default-test) @ futuristic-feline ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.spotify.feline.FelineTest
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.spotify.feline.FelineTest
[INFO] Running com.spotify.feline.FelineStateFutureThrowsTest
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.spotify.feline.FelineStateFutureThrowsTest
[INFO] Running com.spotify.feline.FelineStateConsumerThrowsTest
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.spotify.feline.FelineStateConsumerThrowsTest
[INFO] Running com.spotify.feline.ThreadLocalTest
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.spotify.feline.ThreadLocalTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
```

Seems like surefire is choosing the vintage engine for some reason, so
adding the dependency on the jupiter engine seems to resolve that.
